### PR TITLE
Ensure tile non-null when pixel is zero

### DIFF
--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -141,11 +141,21 @@ class TestPoint(unittest.TestCase):
 
     def test_get_set_tile_x(self):
         self.assertIsNone(self.pt_null.tile_x)
+
+        # verify tile_x of 0 does not result in null
+        self.pt_null.tile_x = 0
+        self.assertIsNotNone(self.pt_null.tile_x)
+
         self.pt_null.tile_x = self.tile_x_14
         self.assertEqual(self.pt_null.tile_x, self.tile_x_14)
 
     def test_get_set_tile_y(self):
         self.assertIsNone(self.pt_null.tile_y)
+
+        # verify tile_y of 0 does not result in null
+        self.pt_null.tile_y = 0
+        self.assertIsNotNone(self.pt_null.tile_y)
+
         self.pt_null.tile_y = self.tile_y_14
         self.assertEqual(self.pt_null.tile_y, self.tile_y_14)
 

--- a/webmercator/point.py
+++ b/webmercator/point.py
@@ -145,7 +145,8 @@ class Point(object):
 
     @property
     def tile_x(self):
-        return int(self.pixel_x / 256) if self.pixel_x else None
+        if self.pixel_x is not None:
+            return int(self.pixel_x / 256)
 
     @tile_x.setter
     def tile_x(self, value):
@@ -153,7 +154,8 @@ class Point(object):
 
     @property
     def tile_y(self):
-        return int(self.pixel_y / 256) if self.pixel_y else None
+        if self.pixel_y is not None:
+            return int(self.pixel_y / 256)
 
     @tile_y.setter
     def tile_y(self, value):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Fix tile if pixel is 0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
failed when pixel = 0 prior to patch

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my processes with this code and it works for me." -->
added assertions which failed prior to patch

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
